### PR TITLE
Fix usage of Currency Code and Text

### DIFF
--- a/CalculatorPlugin/CalculatorPlugin/SumCalculationStep.swift
+++ b/CalculatorPlugin/CalculatorPlugin/SumCalculationStep.swift
@@ -125,11 +125,23 @@ internal extension Notification {
     }
 }
 
+extension Locale {
+    var currencyIdentifier: String? {
+        let locale = Locale.autoupdatingCurrent
+        if #available(iOS 16, *) {
+            return locale.currency?.identifier
+        } else {
+            return locale.currencyCode
+        }
+    }
+}
+
 internal extension CurrencyFormatter {
-    static func `default`(currencyCode: String? = nil, hasDecimals: Bool = false) -> CurrencyFormatter {
+    static func `default`(currencyCode: String? = nil, hasDecimals: Bool = false, locale: Locale = .autoupdatingCurrent) -> CurrencyFormatter {
         CurrencyFormatter {
             $0.hasDecimals = hasDecimals
-            $0.currencyCode = currencyCode ?? "GBP"
+            $0.currencyCode = (currencyCode ?? locale.currencyIdentifier) ?? $0.currencyCode
+            $0.locale = locale
         }
     }
 }

--- a/CalculatorPlugin/CalculatorPlugin/SumCalculationStep.swift
+++ b/CalculatorPlugin/CalculatorPlugin/SumCalculationStep.swift
@@ -82,7 +82,9 @@ public class SumCalculationStepViewController: MWStepViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.addCovering(childViewController: UIHostingController(
-            rootView: SumCalculationStepContentView().environmentObject(self.sumCalculationStep)
+            rootView: SumCalculationStepContentView(
+                currencyFormatter: .default(currencyCode: self.sumCalculationStep.properties.currencyCode)
+            ).environmentObject(self.sumCalculationStep)
         ))
     }
     
@@ -124,10 +126,10 @@ internal extension Notification {
 }
 
 internal extension CurrencyFormatter {
-    static var `default`: CurrencyFormatter {
+    static func `default`(currencyCode: String? = nil, hasDecimals: Bool = false) -> CurrencyFormatter {
         CurrencyFormatter {
-            $0.currency = .poundSterling
-            $0.hasDecimals = false
+            $0.hasDecimals = hasDecimals
+            $0.currencyCode = currencyCode ?? "GBP"
         }
     }
 }

--- a/CalculatorPlugin/CalculatorPlugin/Views/SumCalculationCurrencyItemView.swift
+++ b/CalculatorPlugin/CalculatorPlugin/Views/SumCalculationCurrencyItemView.swift
@@ -19,7 +19,7 @@ struct SumCalculationCurrencyItemView: View {
     
     init(
         item: Binding<CalculatorSumCalculationItem>,
-        currencyFormatter: CurrencyFormatter = .default,
+        currencyFormatter: CurrencyFormatter = .default(),
         numberFormatter: NumberFormatter = NumberFormatter(),
         stringResolution: @escaping (String) -> String = { $0 }
     ) {

--- a/CalculatorPlugin/CalculatorPlugin/Views/SumCalculationStepContentView.swift
+++ b/CalculatorPlugin/CalculatorPlugin/Views/SumCalculationStepContentView.swift
@@ -31,7 +31,7 @@ struct SumCalculationStepContentView: View {
     var body: some View {
         VStack(alignment: .leading) {
             Form {
-                if let text = step.text {
+                if let text = step.properties.text {
                     HStack(alignment: .top) {
                         Image(systemName: "info.circle")
                             .padding(.top, 3)

--- a/CalculatorPlugin/CalculatorPlugin/Views/SumCalculationStepContentView.swift
+++ b/CalculatorPlugin/CalculatorPlugin/Views/SumCalculationStepContentView.swift
@@ -23,7 +23,7 @@ struct SumCalculationStepContentView: View {
     private let currencyFormatter: CurrencyFormatter
     private let numberFormatter: NumberFormatter
 
-    init(currencyFormatter: CurrencyFormatter = .default, numberFormatter: NumberFormatter = NumberFormatter()) {
+    init(currencyFormatter: CurrencyFormatter = .default(), numberFormatter: NumberFormatter = NumberFormatter()) {
         self.currencyFormatter = currencyFormatter
         self.numberFormatter = numberFormatter
     }

--- a/CalculatorPlugin/CalculatorPlugin/Views/SumCalculationTotalView.swift
+++ b/CalculatorPlugin/CalculatorPlugin/Views/SumCalculationTotalView.swift
@@ -13,7 +13,7 @@ struct SumCalculationTotalView: View {
     let total: Double
     let currencyFormatter: CurrencyFormatter
     
-    init(type: SumCalculationType, total: Double, currencyFormatter: CurrencyFormatter = .default) {
+    init(type: SumCalculationType, total: Double, currencyFormatter: CurrencyFormatter = .default()) {
         self.type = type
         self.total = total
         self.currencyFormatter = currencyFormatter


### PR DESCRIPTION
### Issue

The current code is always using £ as currency symbol and the text input by the user is ignored

### Implementation

1. Now, the currency code of the step is used. If no code is passed, the device locale will be used to define the currency code
2. Use the right text property